### PR TITLE
Command to change prefix, botGuild holds prefix on mongoose.

### DIFF
--- a/app.js
+++ b/app.js
@@ -111,6 +111,8 @@ bot.once('ready', async () => {
             });
 
             await botGuild.setCommandStatus(bot);
+
+            guild.commandPrefix = botGuild.prefix;
             
             mainLogger.verbose(`Found a botGuild for ${guild.id} - ${guild.name} on bot ready.`, { event: 'Ready Event' });
         }

--- a/classes/bot-guild.d.ts
+++ b/classes/bot-guild.d.ts
@@ -105,6 +105,11 @@ interface BotGuild extends Document {
     isSetUpComplete: Boolean,
 
     /**
+     * The prefix used by the bot in this guild.
+     */
+     prefix: String,
+
+    /**
      * Will set the minimum required information for the bot to work on this guild.
      * @param {BotGuildInfo} botGuildInfo 
      * @param {CommandoClient} client

--- a/commands/a_utility/change-pre-fix.js
+++ b/commands/a_utility/change-pre-fix.js
@@ -1,0 +1,41 @@
+const { Message } = require('discord.js');
+const PermissionCommand = require('../../classes/permission-command');
+const { messagePrompt } = require('../../classes/prompt');
+const BotGuildModel = require('../../classes/bot-guild');
+
+/**
+ * Gives admin the ability to change the prefix used in the guild by the bot.
+ */
+class ChangePreFix extends PermissionCommand {
+    constructor(client) {
+        super(client, {
+            name: 'change-prefix',
+            group: 'a_utility',
+            memberName: 'change guild prefix',
+            description: 'Change the prefix used in this guild by the bot.',
+            guildOnly: true,
+        }, {
+            role: PermissionCommand.FLAGS.STAFF_ROLE,
+        });
+    }
+
+    /**
+     * @param {BotGuildModel} botGuild 
+     * @param {Message} message 
+     */
+    async runCommand(botGuild, message) {
+        let options = ['!', '#', '$', '%', '&', '?', '|', '°'];
+
+        let prefix = '';
+        while (!options.includes(prefix)) {
+            prefix = (await messagePrompt({ prompt: `What would you like to use as the prefix? Options: ${options.join(', ')}.`, channel: message.channel, userId: message.author.id}, 'string', 45)).content;
+        }
+
+        botGuild.prefix = prefix;
+        botGuild.save();
+
+        message.guild.commandPrefix = prefix;
+
+    }
+}
+module.exports = ChangePreFix;

--- a/db/mongo/BotGuild.d.ts
+++ b/db/mongo/BotGuild.d.ts
@@ -105,6 +105,11 @@ interface BotGuild extends Document {
     isSetUpComplete: Boolean,
 
     /**
+     * The prefix used by the bot in this guild.
+     */
+    prefix: String,
+
+    /**
      * Will set the minimum required information for the bot to work on this guild.
      * @param {BotGuildInfo} botGuildInfo 
      * @param {CommandoClient} client

--- a/db/mongo/BotGuild.js
+++ b/db/mongo/BotGuild.js
@@ -157,7 +157,13 @@ const BotGuildSchema = new Schema({
     isSetUpComplete: {
         type: Boolean,
         default: false,
-    }
+    },
+
+    prefix: {
+        type: String,
+        default: '!',
+        required: true,
+    },
 });
 
 BotGuildSchema.loadClass(BotGuildClass);


### PR DESCRIPTION
Allows admins to change the prefix used. Only a few options are available: ! ? % $ & | °
The information is kept in mongoDB.