### PR TITLE
#214 Added set-bot-activity command, and changed default status

### DIFF
--- a/app.js
+++ b/app.js
@@ -122,7 +122,7 @@ bot.registry
 bot.once('ready', async () => {
     mainLogger.warning('The bot ' + bot.user.username + ' has started and is ready to hack!');
     
-    bot.user.setActivity('Ready to hack!');
+    bot.user.setActivity('nwplus.github.io/Factotum');
 
     // initialize firebase
     const adminSDK = JSON.parse(process.env.NWPLUSADMINSDK);

--- a/commands/a_utility/set-bot-activity.js
+++ b/commands/a_utility/set-bot-activity.js
@@ -1,0 +1,43 @@
+const PermissionCommand = require('../../classes/permission-command');
+const { discordLog } = require('../../discord-services');
+const { Message } = require('discord.js');
+const BotGuildModel = require('../../classes/bot-guild');
+
+/**
+ * The !set-bot-activity will set the bot's activity.
+ * @category Commands
+ * @subcategory Admin-Utility
+ * @extends PermissionCommand
+ */
+class SetBotActivity extends PermissionCommand {
+    constructor(client) {
+        super(client, {
+            name: 'set-bot-activity',
+            group: 'a_utility',
+            memberName: 'set bot activity',
+            description: 'Sets the bot activity.',
+            guildOnly: true,
+            args: [{   
+                key: 'status',
+                prompt: 'the bot status',
+                type: 'string',
+                default: 'nwplus.github.io/Factotum',
+            }]
+        },
+        {
+            role: PermissionCommand.FLAGS.STAFF_ROLE,
+            roleMessage: 'Hey there, the command !set-bot-activity is only available to Staff!',
+        });
+    }
+
+    /**
+     * @param {Message} message - the command message
+     * @param {Object} args
+     * @param {String} args.status
+     */
+     
+    async runCommand(botGuild, message, {status}) {
+        this.client.user.setActivity(status, {type: 'PLAYING'});
+    }
+}
+module.exports = SetBotActivity;


### PR DESCRIPTION
This PR addresses the issue created here: https://github.com/nwplus/Factotum/issues/214

- Changed default bot status to website.
- Added custom command to change bot status

Command:
@params: string is the argument representing the bot status
```
!set-bot-activity string
```