### PR TITLE
Init role fix

### DIFF
--- a/app.js
+++ b/app.js
@@ -399,7 +399,7 @@ async function greetNewMember(member, botGuild) {
             }
         });
     }
-    // if verification is off, then just ive member role
+    // if verification is off, then just give member role
     else {
         discordServices.addRoleToMember(member, botGuild.roleIDs.memberRole);
     }

--- a/classes/Bot/bot-guild.js
+++ b/classes/Bot/bot-guild.js
@@ -137,23 +137,6 @@ class BotGuild {
         memberRole.setMentionable(false);
         memberRole.setPermissions(memberRole.permissions.add(BotGuild.memberPermissions));
 
-        // change the everyone role permissions
-        guild.roles.everyone.setPermissions(0); // no permissions for anything like the guest role
-
-        // make sure admin channels are only for admins
-        let adminCategory = guild.channels.resolve(this.channelIDs.adminConsole).parent
-        adminCategory.overwritePermissions([
-            {
-                id: adminRole.id,
-                allow: 'VIEW_CHANNEL'
-            },
-            {
-                id: this.roleIDs.everyoneRole,
-                deny: ['VIEW_CHANNEL', 'SEND_MESSAGES', 'CONNECT']
-            }
-        ]);
-        adminCategory.children.forEach(channel => channel.lockPermissions());
-
         // create the archive category
         this.channelIDs.archiveCategory = (await this.createArchiveCategory(guild)).id;
 
@@ -230,6 +213,8 @@ class BotGuild {
             parent: adminCategory,
         });
 
+        adminCategory.children.forEach(channel => channel.lockPermissions());
+
         winston.loggers.get(guild.id).event(`The botGuild has run the create admin channels function.`, {event: "Bot Guild"});
 
         return {adminConsoleChannel: adminConsoleChannel, adminLog: adminLogChannel};
@@ -268,6 +253,9 @@ class BotGuild {
         guestRole.setMentionable(false);
         guestRole.setPermissions(0);
         this.verification.guestRoleID = guestRoleId;
+
+        // change the everyone role permissions
+        guild.roles.everyone.setPermissions(0); // no permissions for anything like the guest role
 
         if (verificationChannels) {
             this.verification.welcomeChannelID = verificationChannels.welcomeChannelID;

--- a/classes/Bot/bot-guild.js
+++ b/classes/Bot/bot-guild.js
@@ -137,6 +137,10 @@ class BotGuild {
         memberRole.setMentionable(false);
         memberRole.setPermissions(memberRole.permissions.add(BotGuild.memberPermissions));
 
+        // change the everyone role permissions, we do this so that we can lock rooms. For users to see the server when 
+        // verification is off, they need to get the member role when greeted by the bot!
+        guild.roles.everyone.setPermissions(0); // no permissions for anything like the guest role
+
         // create the archive category
         this.channelIDs.archiveCategory = (await this.createArchiveCategory(guild)).id;
 
@@ -253,9 +257,6 @@ class BotGuild {
         guestRole.setMentionable(false);
         guestRole.setPermissions(0);
         this.verification.guestRoleID = guestRoleId;
-
-        // change the everyone role permissions
-        guild.roles.everyone.setPermissions(0); // no permissions for anything like the guest role
 
         if (verificationChannels) {
             this.verification.welcomeChannelID = verificationChannels.welcomeChannelID;

--- a/commands/essentials/init-bot.js
+++ b/commands/essentials/init-bot.js
@@ -59,7 +59,7 @@ class InitBot extends Command {
         await new Promise((resolve) => setTimeout(resolve, 15000));
 
         // grab the admin role
-        const adminRole = await this.askOrCreate('admin', channel, userId, guild, '#008369');
+        const adminRole = await this.askOrCreate('admin', channel, userId, guild, '#008369', 'This role will have the administrator permission. Careful who you give this to!');
         addRoleToMember(message.member, adminRole);
 
         // create the admin channel room
@@ -88,11 +88,11 @@ class InitBot extends Command {
         await new Promise((resolve) => setTimeout(resolve, 15000));
 
         // grab the staff role
-        const staffRole = await this.askOrCreate('staff', channel, userId, guild, '#00D166');
+        const staffRole = await this.askOrCreate('staff', channel, userId, guild, '#00D166', 'This role will have all permissions except the administrator permission.');
         adminConsole.addField('The staff role:', `<@&${staffRole.id}>`);
 
         // get the regular member, this role will have the general member permissions
-        const memberRole = await this.askOrCreate('member', channel, userId, guild, '#006798');
+        const memberRole = await this.askOrCreate('member', channel, userId, guild, '#006798', 'This role will be given to all users when they either join the server, or verify.');
         adminConsole.addField('The member role:', `<@&${memberRole.id}>`);
 
         // bot support channel prompt
@@ -299,12 +299,13 @@ class InitBot extends Command {
      * @param {Snowflake} userId - the user id to prompt to 
      * @param {Guild} guild - the current guild
      * @param {ColorResolvable} - the role color
+     * @param {String} extraText - any extra text to add to the prompt
      * @async
      * @returns {Promise<Role>}
      */
-    async askOrCreate(roleName, channel, userId, guild, color) {
+    async askOrCreate(roleName, channel, userId, guild, color, extraText) {
         try {
-            let hasRole = await SpecialPrompt.boolean({ prompt: 'Have you created the ' + roleName + ' role? You can go ahead and create it if you wish, or let me do the hard work.', channel, userId });
+            let hasRole = await SpecialPrompt.boolean({ prompt: 'Have you created the ' + roleName + ' role? You can go ahead and create it if you wish, or let me do the hard work. ' + extraText, channel, userId });
             if (hasRole) {
                 return await RolePrompt.single({ prompt: 'What is the ' + roleName + ' role?', channel, userId });
             } else {

--- a/commands/essentials/init-bot.js
+++ b/commands/essentials/init-bot.js
@@ -126,7 +126,9 @@ class InitBot extends Command {
             // ask for guest role
             var guestRole = await this.askOrCreate('guest', channel, userId, guild, '#969C9F');
 
-            let infoMsg = await sendMsgToChannel(channel, userId, 'I need to know what types to verify when a user tries to verify. Please follow the instructions, it will let you add as many types as you wish.');
+            let infoMsg = await sendMsgToChannel(channel, userId, `I need to know what types to verify when a user tries to verify. \
+            Please follow the instructions, it will let you add as many types as you wish. The ${memberRole.name} role will be added to all users who validate correctly! \
+            You will have to create the new roles yourself! Do this before adding them as a verification type.`);
 
             let types = await this.getVerificationTypes(channel, userId);
             infoMsg.delete();


### PR DESCRIPTION
# TL;DR
Closes #228, and improves init-bot.

# Description
Improved documentation and user prompts for init-bot role creations.

We keep the everyone role without any perms so that rooms can be locked properly. When users join a server without verification, they still get the member role, this role gives them the permissions they need.

This is explained to the administrator when the bot asks about such roles.

## Why
To improve user experience.

## User Changes
More explanation on init-bot command.

## Tests Done
Manual tests with and without verification.

# Breaking Changes
None