### PR TITLE
Verification: ask to opt-in for Codex

### DIFF
--- a/app.js
+++ b/app.js
@@ -398,6 +398,7 @@ async function greetNewMember(member, botGuild) {
     // if verification is on then give guest role and let user verify
     if (botGuild.verification.isEnabled) {
         discordServices.addRoleToMember(member, botGuild.verification.guestRoleID);
+        let askedAboutCodex = false;
 
         msg.react(verifyEmoji);
         let verifyCollector = msg.createReactionCollector((reaction, user) => !user.bot && reaction.emoji.name === verifyEmoji);
@@ -415,6 +416,19 @@ async function greetNewMember(member, botGuild) {
 
             try {
                 await Verification.verify(member, email, member.guild, botGuild);
+                if (!askedAboutCodex && await firebaseServices.checkCodexActive(member.guild.id)) { 
+                    try {
+                        discordServices.askBoolQuestion(member,botGuild, 'One more thing!', 
+                        'Would you to receive free [Codex beta](https://openai.com/blog/openai-codex/) access, courtesy of our sponsor OpenAI (first come first served, while supplies last)? If so, please react with a 👍',
+                        'Thanks for indicating your interest, you have been added to the list! Keep an eye on your email.', email);
+                        askedAboutCodex = true;
+                    } catch (error) {
+                        discordServices.sendEmbedToMember(member, {
+                            title: 'Oops, something went wrong',
+                            description: 'Please contact an nwPlus member'
+                        }, false);
+                    }
+                }
             } catch (error) {
                 discordServices.sendEmbedToMember(member, {
                     title: 'Verification Error',
@@ -422,6 +436,7 @@ async function greetNewMember(member, botGuild) {
                 }, true);
             }
         });
+        
     }
     // if verification is off, then just give member role
     else {

--- a/app.js
+++ b/app.js
@@ -416,11 +416,12 @@ async function greetNewMember(member, botGuild) {
 
             try {
                 await Verification.verify(member, email, member.guild, botGuild);
-                if (!askedAboutCodex && await firebaseServices.checkCodexActive(member.guild.id)) { 
+                if (!askedAboutCodex && await firebaseServices.checkCodexActive(member.guild.id)
+                    && discordServices.checkForRole(member, botGuild.verification.verificationRoles.get('hacker'))) { 
                     try {
                         discordServices.askBoolQuestion(member,botGuild, 'One more thing!', 
-                        'Would you to receive free [Codex beta](https://openai.com/blog/openai-codex/) access, courtesy of our sponsor OpenAI (first come first served, while supplies last)? If so, please react with a 👍',
-                        'Thanks for indicating your interest, you have been added to the list! Keep an eye on your email.', email);
+                        'Would you like to receive free [Codex beta](https://openai.com/blog/openai-codex/) access, courtesy of our sponsor OpenAI (first come first served, while supplies last)? If so, please react with a 👍',
+                        'Thanks for indicating your interest, you have been added to the list! If you are selected to receive an API key, you will get an email.', email);
                         askedAboutCodex = true;
                     } catch (error) {
                         discordServices.sendEmbedToMember(member, {

--- a/db/firebase/firebase-services.js
+++ b/db/firebase/firebase-services.js
@@ -287,3 +287,36 @@ async function attend(id, guildId) {
     }
 }
 module.exports.attend = attend;
+
+/**
+ * check if codex is set to active (very hacky atm, it's just a document in the "codex" collection with a boolean 
+ * field called "active")
+ * @param {String} guildId 
+ * @returns boolean of whether codex is set to active
+ */
+
+async function checkCodexActive(guildId) {
+    var ref = apps.get('nwPlusBotAdmin').firestore().collection('guilds').doc(guildId).collection('codex').doc('active');
+    var activeRef = await ref.get();
+    const data = activeRef.data();
+    return data.active;
+}
+module.exports.checkCodexActive = checkCodexActive;
+
+/**
+ * stores email to firebase collection
+ * @param {String} guildId 
+ * @param {String} collection - name of collection to store email in
+ * @param {String} email - user's email
+ */
+
+async function saveToFirebase(guildId, collection, email) {
+    var ref = apps.get('nwPlusBotAdmin').firestore().collection('guilds').doc(guildId).collection(collection).doc(email.toLowerCase());
+    /** @type {FirebaseUser} */
+    let data = {
+        email: email.toLowerCase()
+    };
+
+    await ref.set(data);
+}
+module.exports.saveToFirebase = saveToFirebase;


### PR DESCRIPTION
# Description
New Feature - bot asks hackers if they would like to opt in for Codex beta first time they try to verify. 

1. Hacker verifies email with bot
2. Bot confirms the email was verified, and sends a separate embed asking if they'd like to opt in for Codex beta
3. If hacker wants to opt in, they click the thumbs up react, else they leave it
4. As soon as thumbs up is pressed, a confirmation message is sent to hacker and bot adds a new document to the guild > "codex" collection in Firebase with the field "email" which is the email the hacker used to verify

If the hacker presses the verify react multiple times, this Codex embed will only show up the first time they type in a valid email. The feature can be toggled using the document in the "codex" collection named "active" which has a field named "active" which is a boolean - when it is active it is true, false otherwise (ik it's hacky but I'm too lazy to figure out the botGuild settings in Mongo).

## Why
Requested by OpenAI, we need to get a list of emails of hackers interested in using Codex beta.


https://user-images.githubusercontent.com/59301359/148653730-df4b15f5-c6f1-4ab5-810e-05075c7d4df5.mp4


## Further Considerations
So far I haven't limited the number of hackers who can opt in since it can get complex with the number of edge cases and/or expensive in terms of operational efficiency. Even if we get more hackers than API keys available, we can just take the first 200 people and if any of them are ineligible or decide they don't want one, we can move down the list.
