### PR TITLE
Save pronoun messages

### DIFF
--- a/commands/a_utility/pronouns.js
+++ b/commands/a_utility/pronouns.js
@@ -2,7 +2,7 @@ const { Command } = require('@sapphire/framework');
 const { Interaction, MessageEmbed, PermissionFlagsBits, Guild, Message, MessageManager } = require('discord.js');
 const firebaseUtil = require('../../db/firebase/firebaseUtil');
 
-var emojis = ['1️⃣', '2️⃣', '3️⃣', '4️⃣'];
+const emojis = ['1️⃣', '2️⃣', '3️⃣', '4️⃣'];
 
 /**
  * The pronouns command sends a role reaction console for users to select a pronoun role out of 4 options:

--- a/commands/a_utility/pronouns.js
+++ b/commands/a_utility/pronouns.js
@@ -10,7 +10,6 @@ const emojis = ['1️⃣', '2️⃣', '3️⃣', '4️⃣'];
  * * he/him
  * * they/them
  * * other pronouns
- * The roles must be already created on the server for this to work.
  * @category Commands
  * @subcategory Admin-Utility
  * @extends Command
@@ -47,7 +46,7 @@ class Pronouns extends Command {
             return;
         }
         
-        const { sheRole, heRole, theyRole, otherRole } = getPronounRoles(guild);
+        const { sheRole, heRole, theyRole, otherRole } = await getPronounRoles(guild);
 
         // check to make sure all 4 roles are available
         if (!sheRole || !heRole || !theyRole || !otherRole) {
@@ -110,12 +109,32 @@ class Pronouns extends Command {
  * 
  * @param {Guild} guild 
  */
-function getPronounRoles(guild) {
-    const sheRole = guild.roles.cache.find(role => role.name === 'she/her');
-    const heRole = guild.roles.cache.find(role => role.name === 'he/him');
-    const theyRole = guild.roles.cache.find(role => role.name === 'they/them');
-    const otherRole = guild.roles.cache.find(role => role.name === 'other pronouns');
+async function getPronounRoles(guild) {
+    const sheRole = guild.roles.cache.find(role => role.name === 'she/her') || await createRole(guild, 'she/her', '#99AAB5');
+    const heRole = guild.roles.cache.find(role => role.name === 'he/him') || await createRole(guild, 'he/him', '#99AAB5');
+    const theyRole = guild.roles.cache.find(role => role.name === 'they/them') || await createRole(guild, 'they/them', '#99AAB5');
+    const otherRole = guild.roles.cache.find(role => role.name === 'other pronouns') || await createRole(guild, 'other pronouns', '#99AAB5');
     return { sheRole, heRole, theyRole, otherRole };
+}
+
+/**
+ * Creates a role in the guild with the specified name and color.
+ * @param {Guild} guild 
+ * @param {string} name 
+ * @param {string} color 
+ */
+ async function createRole(guild, name, color) {
+    try {
+        const role = await guild.roles.create({
+            name: name,
+            color: color,
+            reason: `Creating ${name} role for pronoun selector`
+        });
+        return role;
+    } catch (error) {
+        console.error(`Failed to create role ${name}:`, error);
+        throw new Error(`Could not create role ${name}`);
+    }
 }
 
 /**
@@ -123,8 +142,8 @@ function getPronounRoles(guild) {
  * @param {Guild} guild
  * @param {Message} message 
  */
-function listenToReactions(guild, message) {
-    const { sheRole, heRole, theyRole, otherRole } = getPronounRoles(guild);
+async function listenToReactions(guild, message) {
+    const { sheRole, heRole, theyRole, otherRole } = await getPronounRoles(guild);
 
     let filter = (reaction, user) => {
         return user.bot != true && emojis.includes(reaction.emoji.name);

--- a/db/firebase/firebaseUtil.js
+++ b/db/firebase/firebaseUtil.js
@@ -79,6 +79,13 @@ module.exports = {
         }
         return externalProjectsCol.doc('Factotum').collection('InitBotInfo');
     },
+    /**
+     * @param {string} guildId 
+     */
+    getSavedMessagesSubCol(guildId) {
+        const factotumSubCol = this.getFactotumSubCol();
+        return factotumSubCol.doc(guildId).collection('SavedMessages');
+    },
 
     /**
      * @param {String} appName


### PR DESCRIPTION
# TL;DR
Reactions to pronoun messages now work after restarting the bot

# Description
When the `/pronoun` command is run, it now saves a copy of the message ID and channel ID to Firebase under the `InitBotInfo > [server ID] > SavedMessages -> pronouns` document. When the bot is restarted, it will check for this document, and if there is an existing message/channel saved, it will use those to start emoji reaction listeners, allowing the old message to continue to be used for pronoun role reactions.

In addition, the bot startup was also changed so that each server is initialized sequentially instead of in parallel. This just makes the debug messages less confusing since they're not being logged asynchronously.

## Why
If the bot crashes, we will lose emoji reaction listeners on messages that have already been sent. This change will allow us to more easily recover from bot crashes.

## User Changes
None :D

## Tests Done
Tested restarting the bot and adding/removing reaction emojis, then verifying that roles are added/removed correspondingly

# Breaking Changes
None - if no existing saved message is found, the bot just continues as normal