### PR TITLE
Get hacker data from DB -> fixing the /start-verification command

### DIFF
--- a/commands/verification/check-email.js
+++ b/commands/verification/check-email.js
@@ -22,27 +22,17 @@ class CheckEmail extends Command {
         )
     }
 
-    // IS EDITED
     async chatInputRun(interaction) {
         this.initBotInfo = await firebaseUtil.getInitBotInfo(interaction.guild.id);
         const guild = interaction.guild;
-        console.log(guild, ' is the guild');
         const email = interaction.options.getString('email');
         const userId = interaction.user.id;
-        console.log(userId, ' is the userId');
 
-        console.log(email, ' is the email');
         if (!guild.members.cache.get(userId).roles.cache.has(this.initBotInfo.roleIDs.staffRole) && !guild.members.cache.get(userId).roles.cache.has(this.initBotInfo.roleIDs.adminRole)) {
             return this.error({ message: 'You do not have permissions to run this command!', ephemeral: true })
         }
         
         let botSpamChannel = guild.channels.resolve(this.initBotInfo.channelIDs.botSpamChannel);
-        if (!botSpamChannel) {
-            return interaction.reply({
-                content: `The channel with ID ${this.initBotInfo.channelIDs.botSpamChannel} could not be found. Please check the configuration.`,
-                ephemeral: true
-            });
-        }
 
         const userData = await checkEmail(email, guild.id);       
         interaction.reply({content: 'Visit <#' + this.initBotInfo.channelIDs.botSpamChannel + '> for the results', ephemeral: true});

--- a/commands/verification/check-email.js
+++ b/commands/verification/check-email.js
@@ -22,16 +22,28 @@ class CheckEmail extends Command {
         )
     }
 
+    // IS EDITED
     async chatInputRun(interaction) {
         this.initBotInfo = await firebaseUtil.getInitBotInfo(interaction.guild.id);
         const guild = interaction.guild;
+        console.log(guild, ' is the guild');
         const email = interaction.options.getString('email');
+        const userId = interaction.user.id;
+        console.log(userId, ' is the userId');
 
+        console.log(email, ' is the email');
         if (!guild.members.cache.get(userId).roles.cache.has(this.initBotInfo.roleIDs.staffRole) && !guild.members.cache.get(userId).roles.cache.has(this.initBotInfo.roleIDs.adminRole)) {
             return this.error({ message: 'You do not have permissions to run this command!', ephemeral: true })
         }
         
         let botSpamChannel = guild.channels.resolve(this.initBotInfo.channelIDs.botSpamChannel);
+        if (!botSpamChannel) {
+            return interaction.reply({
+                content: `The channel with ID ${this.initBotInfo.channelIDs.botSpamChannel} could not be found. Please check the configuration.`,
+                ephemeral: true
+            });
+        }
+
         const userData = await checkEmail(email, guild.id);       
         interaction.reply({content: 'Visit <#' + this.initBotInfo.channelIDs.botSpamChannel + '> for the results', ephemeral: true});
 

--- a/commands/verification/check-email.js
+++ b/commands/verification/check-email.js
@@ -26,14 +26,12 @@ class CheckEmail extends Command {
         this.initBotInfo = await firebaseUtil.getInitBotInfo(interaction.guild.id);
         const guild = interaction.guild;
         const email = interaction.options.getString('email');
-        const userId = interaction.user.id;
 
         if (!guild.members.cache.get(userId).roles.cache.has(this.initBotInfo.roleIDs.staffRole) && !guild.members.cache.get(userId).roles.cache.has(this.initBotInfo.roleIDs.adminRole)) {
             return this.error({ message: 'You do not have permissions to run this command!', ephemeral: true })
         }
         
         let botSpamChannel = guild.channels.resolve(this.initBotInfo.channelIDs.botSpamChannel);
-
         const userData = await checkEmail(email, guild.id);       
         interaction.reply({content: 'Visit <#' + this.initBotInfo.channelIDs.botSpamChannel + '> for the results', ephemeral: true});
 

--- a/commands/verification/start-verification.js
+++ b/commands/verification/start-verification.js
@@ -97,7 +97,7 @@ class StartVerification extends Command {
                     return;
                 }
 
-                var correctTypes = [];
+                let correctTypes = [];
                 types.forEach(type => {
                     console.log(type, ' is the TYPE');
                     const roleObj = this.initBotInfo.verification.roles.find(role => role.name === type);
@@ -122,8 +122,6 @@ class StartVerification extends Command {
                         } else {
                             console.warn(`Could not add role: ${roleId} for type: ${type}`);
                         }
-
-                        correctTypes.push(type);
                     } else {
                         discordLog(interaction.guild, `VERIFY WARNING: <@${submitted.user.id}> was of type ${type} but I could not find that type!`);
                     }

--- a/commands/verification/start-verification.js
+++ b/commands/verification/start-verification.js
@@ -99,7 +99,9 @@ class StartVerification extends Command {
 
                 var correctTypes = [];
                 types.forEach(type => {
-                    if (this.initBotInfo.verification.verificationRoles.has(type) || type === 'staff' || type === 'mentor') {
+                    console.log(type, ' is the TYPE');
+                    const roleObj = this.initBotInfo.verification.roles.find(role => role.name === type);
+                    if (roleObj || type === 'staff' || type === 'mentor') {
                         const member = interaction.guild.members.cache.get(submitted.user.id);
                         let roleId;
                         if (type === 'staff') {
@@ -107,13 +109,20 @@ class StartVerification extends Command {
                         } else if (type === 'mentor') {
                             roleId = this.initBotInfo.roleIDs.mentorRole;
                         } else {
-                            roleId = this.initBotInfo.verification.verificationRoles.get(type);
+                            roleId = roleObj.roleId;
                         }
-                        member.roles.add(roleId);
-                        if (correctTypes.length === 0) {
-                            member.roles.remove(this.initBotInfo.verification.guestRoleID);
-                            member.roles.add(this.initBotInfo.roleIDs.memberRole);
+                        if (member && roleId) {
+                            member.roles.add(roleId);
+                
+                            if (correctTypes.length === 0) {
+                                member.roles.remove(this.initBotInfo.verification.guestRoleID);
+                                member.roles.add(this.initBotInfo.roleIDs.memberRole);
+                            }
+                            correctTypes.push(type);
+                        } else {
+                            console.warn(`Could not add role: ${roleId} for type: ${type}`);
                         }
+
                         correctTypes.push(type);
                     } else {
                         discordLog(interaction.guild, `VERIFY WARNING: <@${submitted.user.id}> was of type ${type} but I could not find that type!`);

--- a/db/firebase/firebaseUtil.js
+++ b/db/firebase/firebaseUtil.js
@@ -257,27 +257,38 @@ module.exports = {
      */
     async verify(email, id, guildId) {
         let emailLowerCase = email.trim().toLowerCase();
-        let userRef = getFactotumDoc().collection('guilds').doc(guildId).collection('members').where('email', '==', emailLowerCase).limit(1);
+        let userRef = getFactotumDoc().collection('InitBotInfo').doc(guildId).collection('applicants').where('email', '==', emailLowerCase).limit(1);
         let user = (await userRef.get()).docs[0];
+        let otherRolesRef = getFactotumDoc().collection('InitBotInfo').doc(guildId).collection('otherRoles').where('email', '==', emailLowerCase).limit(1);
+        let otherRolesUser = (await otherRolesRef.get()).docs[0];
         if (user) {
             let returnTypes = [];
 
             /** @type {FirebaseUser} */
             let data = user.data();
-
-            data.types.forEach((value, index, array) => {
-                if (!value.isVerified) {
-                    value.isVerified = true;
-                    value.VerifiedTimestamp = admin.firestore.Timestamp.now();
-                    returnTypes.push(value.type);
-                }
-            });
-
-            data.discordId = id;
-
-            user.ref.update(data);
+            if (!data?.isVerified) {
+                data.isVerified = true;
+                data.VerifiedTimestamp = admin.firestore.Timestamp.now();
+                data.discordId = id;
+                await user.ref.update(data);
+                returnTypes.push("hacker")
+            }
 
             return returnTypes;
+        } else if (otherRolesUser) {
+            let returnTypes = [];
+
+            /** @type {FirebaseUser} */
+            let data = otherRolesUser.data();
+            if (!data?.isVerified) {
+                data.isVerified = true;
+                data.VerifiedTimestamp = admin.firestore.Timestamp.now();
+                data.discordId = id;
+                await otherRolesUser.ref.update(data);
+                returnTypes.push(data?.role)
+            }
+
+            return returnTypes;            
         } else {
             throw new Error('The email provided was not found!');
         }


### PR DESCRIPTION
# TL;DR
now an admin can call `/start-verification` and verify emails

the order that the verification goes in is as follows:
- first it checks if the email belongs to a hacker (checks in Factotum->InitBotInfo->{discordServerId}->applicants)
- if it does, then set fields `isVerified = true`, `discordId = {discordId}` and the verifiedTimestamp
- otherwise it will check if the email belongs to a user that is ANOTHER role other than hacker (ex. mentor, etc) (checks in Factotum->InitBotInfo->{discordServerId}->otherRoles)
- if it does, then set the above fields
- if this also fails then the email cannot be verified

# Description/Changes made
- created 2 new collections -> `applicants` and `otherRoles`
- the base schema needed for `applicants` is: {email: ${email}, isVerified: false}
- the base schema needed for `otherRoles` is: {email: ${email}, role: "mentor"} (can replace mentor with another role)

## Why
- this allows us to verify emails of hackers AND individuals of other roles (a central place for us to add info for latecomers too)

## User Changes

## How to test
- make sure server is initialized
- create an `applicants` collection and `otherRoles` collection in the `initBotInfo` of your discord server on firebase
- add users accordingly
- run `/start-verification` and enter in any email
- if entered a valid email, check that `isVerified = true`

## Tests done
- tested validating a hacker in the `applicants` collection
- tested validating a mentor in the `otherRoles` collection
- tested validating an email in neither

# Breaking Changes
