### PR TITLE
add members + verify for hackers + other roles

### DIFF
--- a/commands/verification/add-members.js
+++ b/commands/verification/add-members.js
@@ -33,16 +33,31 @@ class AddMembers extends Command {
         const guild = interaction.guild;
         const participantsType = interaction.options.getString('participantstype');
         const overwrite = interaction.options.getBoolean('overwrite') ?? false;
+        
+        const userRoles = guild.members.cache.get(userId).roles.cache;
+        const staffRoleID = this.initBotInfo.roleIDs.staffRole;
+        const adminRoleID = this.initBotInfo.roleIDs.adminRole;
+        console.log(this.initBotInfo, ' is the initBotInfo');
+        console.log(this.initBotInfo.roleIDs, ' is the roleIds');
+        console.log(userId);
+        console.log(guild);
+        console.log(participantsType);
+        console.log(overwrite);
+        console.log(' ');
 
-        if (!guild.members.cache.get(userId).roles.cache.has(this.initBotInfo.roleIDs.staffRole) && !guild.members.cache.get(userId).roles.cache.has(this.initBotInfo.roleIDs.adminRole)) {
-            return this.error({ message: 'You do not have permissions to run this command!', ephemeral: true })
+        if (!userRoles.has(staffRoleID) && !userRoles.has(adminRoleID)) {
+            return this.error({ message: 'You do not have permissions to run this command!', ephemeral: true });
         }
 
-        if (!this.initBotInfo.verification.verificationRoles.has(participantsType)) {
+        console.log('PASSED');
+
+        const roles = this.initBotInfo.verification.roles;
+        const roleExists = roles.some(role => role.name === participantsType);
+        if (!roleExists) {
             await interaction.reply({ content: 'The role you entered does not exist!', ephemeral: true });
             return;
         }
-        
+        console.log('PASSED AGAIN');
         const modal = new Modal()
                         .setCustomId('emailsModal')
                         .setTitle('Enter all emails to be added as ' + participantsType)
@@ -63,7 +78,8 @@ class AddMembers extends Command {
 
                     if (submitted) {
                         const emailsRaw = submitted.fields.getTextInputValue('emails');
-                        const emails = emailsRaw.split(/\r?\n|\r|\n/g);
+                        console.log(emailsRaw, ' is the raw emails');
+                        const emails = emailsRaw.split(/[\r?\n|\r|\n|,]+/g).map(email => email.trim()).filter(Boolean);
                         emails.forEach(email => {
                             addUserData(email, participantsType, interaction.guild.id, overwrite);
                         });


### PR DESCRIPTION
# TL;DR
- base functionality for add members + verify members for both `hacker` roles + other roles (such as `photographer`)
- the data gets saved in this format
- `InitBotInfo -> {Guild_Id} -> applicants` for participants with the `hacker` role
- `InitBotInfo -> {Guild_Id} -> otherRoles` for participants with other roles

# Description
New Feature/Bug Fix ...

## Why

## User Changes

## Tests Done

# Breaking Changes
