### PR TITLE
Organizer check in command

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,6 +14,7 @@ const { LogLevel, SapphireClient } = require('@sapphire/framework');
 const Pronouns = require('./commands/a_utility/pronouns');
 const RoleSelector = require('./commands/a_utility/role-selector');
 const StartReport = require('./commands/hacker_utility/start-report');
+const OrganizerCheckIn = require('./commands/a_utility/organizer-check-in');
 
 /**
  * The Main App module houses the bot events, process events, and initializes
@@ -222,6 +223,15 @@ bot.once('ready', async () => {
                     mainLogger.warning(startReportError);
                 } else {
                     mainLogger.verbose('Restored start report command message');
+                }
+
+                /** @type {OrganizerCheckIn} */
+                const organizerCheckInCommand = bot.stores.get('commands').get('organizer-check-in');
+                const organizerCheckInError = await organizerCheckInCommand.tryRestoreReactionListeners(guild);
+                if (organizerCheckInError) {
+                    mainLogger.warning(organizerCheckInError);
+                } else {
+                    mainLogger.verbose('Restored organizer check-in command message');
                 }
             }
 

--- a/commands/a_utility/organizer-check-in.js
+++ b/commands/a_utility/organizer-check-in.js
@@ -1,0 +1,163 @@
+const { Command } = require('@sapphire/framework');
+const { Interaction, MessageEmbed, Guild, Message, MessageActionRow, MessageButton } = require('discord.js');
+const firebaseUtil = require('../../db/firebase/firebaseUtil');
+
+/**
+ * The organizer-check-in command lets organizers check in/out for attendance.
+ * @category Commands
+ * @subcategory Admin-Utility
+ * @extends Command
+ */
+class OrganizerCheckIn extends Command {
+    constructor(context, options) {
+        super(context, {
+            ...options,
+            description: 'Let organizers check in/out for attendance.'
+        });
+    }
+
+    /**
+     * 
+     * @param {Command.Registry} registry 
+     */
+    registerApplicationCommands(registry) {
+        registry.registerChatInputCommand(
+            (builder) =>
+                builder.setName(this.name).setDescription(this.description),
+            {
+                idHints: '1344923545154617357',
+            }
+        );
+    }
+
+    /**
+     * 
+     * @param {Interaction} interaction
+     */
+    async chatInputRun(interaction) {
+        const guild = interaction.guild;
+        this.initBotInfo = await firebaseUtil.getInitBotInfo(guild.id);
+        const userId = interaction.user.id;
+        if (!guild.members.cache.get(userId).roles.cache.has(this.initBotInfo.roleIDs.staffRole) && !guild.members.cache.get(userId).roles.cache.has(this.initBotInfo.roleIDs.adminRole)) {
+            interaction.reply({ content: 'You do not have permissions to run this command!', ephemeral: true });
+            return;
+        }
+
+        const row = new MessageActionRow().addComponents(
+            new MessageButton()
+                .setCustomId('check-in')
+                .setLabel('Check In')
+                .setStyle('PRIMARY')
+        ).addComponents(
+            new MessageButton()
+                .setCustomId('check-out')
+                .setLabel('Check Out')
+                .setStyle('PRIMARY')
+        );
+        
+        const embed = generateAttendanceEmbed(this.initBotInfo);
+        let checkInPanel = await interaction.channel.send({
+            content: 'Make sure to check in/out when you enter and leave the venue!',
+            components: [row],
+            embeds: [embed]
+        });
+        interaction.reply({content: 'Organizer check-in started!', ephemeral: true});
+        
+        await listenToReactions(guild, checkInPanel);
+
+        const savedMessagesCol = firebaseUtil.getSavedMessagesSubCol(guild.id);
+        await savedMessagesCol.doc('organizer-check-in').set({
+            messageId: checkInPanel.id,
+            channelId: checkInPanel.channel.id,
+        });
+    }
+
+    /**
+     * Checks Firebase for an existing stored panel listener -
+     * restores the listeners for the panel if it exists, otherwise does nothing
+     * @param {Guild} guild 
+     */
+    async tryRestoreReactionListeners(guild) {
+        const savedMessagesSubCol = firebaseUtil.getSavedMessagesSubCol(guild.id);
+        const organizerCheckInDoc = await savedMessagesSubCol.doc('organizer-check-in').get();
+        if (organizerCheckInDoc.exists) {
+            const { messageId, channelId } = organizerCheckInDoc.data();
+            const channel = await this.container.client.channels.fetch(channelId);
+            if (channel) {
+                try {
+                    const initBotInfo = await firebaseUtil.getInitBotInfo(guild.id);
+
+                    /** @type {Message} */
+                    const message = await channel.messages.fetch(messageId);
+                    const updatedEmbed = generateAttendanceEmbed(initBotInfo);
+                    await message.edit({ embeds: [updatedEmbed] });
+                    await listenToReactions(guild, message);
+                } catch (e) {
+                    // message doesn't exist anymore
+                    return e;
+                }
+            } else {
+                return 'Saved message channel does not exist';
+            }
+        } else {
+            return 'No existing saved message for organizer check-in command';
+        }
+    }
+}
+
+/**
+ * Generates an embed with the current list of organizers present
+ * @param {FirebaseFirestore.DocumentData | null | undefined} initBotInfo 
+ * @returns {MessageEmbed}
+ */
+function generateAttendanceEmbed(initBotInfo) {
+    /** @type {string[]} */
+    const organizerAttendance = Object.values(initBotInfo.organizerAttendance ?? {});
+    organizerAttendance.sort();
+    const formattedMessage = organizerAttendance.map(organizer => `- ${organizer}`).join('\n');
+
+    const embed = new MessageEmbed()
+        .setColor('#0DEFE1')
+        .setTitle('Organizers Present')
+        .setDescription(formattedMessage);
+    return embed;
+}
+
+/**
+ * Adds button listeners to a message to check in/out for organizer attendance
+ * @param {Guild} guild
+ * @param {Message} message 
+ */
+async function listenToReactions(guild, message) {
+    const initBotInfo = await firebaseUtil.getInitBotInfo(guild.id);
+
+    const filter = (i) =>
+        !i.user.bot &&
+      (guild.members.cache
+          .get(i.user.id)
+          .roles.cache.has(initBotInfo.roleIDs.staffRole) ||
+        guild.members.cache
+            .get(i.user.id)
+            .roles.cache.has(initBotInfo.roleIDs.adminRole));
+
+    // create collector
+    const collector = message.createMessageComponentCollector({ filter });
+    collector.on('collect', async i => {
+        const newInitBotInfo = await firebaseUtil.getInitBotInfo(guild.id);
+        if (!newInitBotInfo.organizerAttendance) newInitBotInfo.organizerAttendance = {};
+
+        const user = guild.members.cache.get(i.user.id);
+        if (i.customId == 'check-in') {
+            newInitBotInfo.organizerAttendance[user.user.username] = user.displayName;
+            await i.reply({ content: `Checked in ${user.displayName}`, ephemeral: true });
+        } else if (i.customId == 'check-out') {
+            delete newInitBotInfo.organizerAttendance[user.user.username];
+            await i.reply({ content: `Checked out ${user.displayName}`, ephemeral: true });
+        }
+        await firebaseUtil.updateOrganizerAttendance(guild.id, newInitBotInfo.organizerAttendance);
+        const updatedEmbed = generateAttendanceEmbed(newInitBotInfo);
+        await message.edit({ embeds: [updatedEmbed] });
+    });
+}
+
+module.exports = OrganizerCheckIn;

--- a/commands/a_utility/organizer-check-in.js
+++ b/commands/a_utility/organizer-check-in.js
@@ -3,7 +3,9 @@ const { Interaction, MessageEmbed, Guild, Message, MessageActionRow, MessageButt
 const firebaseUtil = require('../../db/firebase/firebaseUtil');
 
 /**
- * The organizer-check-in command lets organizers check in/out for attendance.
+ * The organizer-check-in command lets organizers check in/out for attendance. It uses the organizerAttendance
+ * field in the InitBotInfo document to store the list of organizers present. organizerAttendance is a map of
+ * organizer username to organizer display name.
  * @category Commands
  * @subcategory Admin-Utility
  * @extends Command

--- a/db/firebase/firebaseUtil.js
+++ b/db/firebase/firebaseUtil.js
@@ -437,6 +437,11 @@ module.exports = {
         return winners;
     },
 
+    async updateOrganizerAttendance(guildId, organizerAttendance) {
+        const ref = module.exports.getFactotumSubCol().doc(guildId);
+        await ref.update({ organizerAttendance });
+    }
+
 };
 
 function getFactotumDoc() {


### PR DESCRIPTION
# TL;DR

New command to track which organizers are present

# Description

Added the `/organizer-check-in` command which sends a leaderboard message in the channel

![image](https://github.com/user-attachments/assets/7d180e64-1e25-44c4-b793-6fd67556d5af)

Organizers can click "Check in" to be added to the list and "Check out" to be removed from the list. In firebase, attendance is stored as a map of username to display name.

## Why

Track who's at the venue :3
